### PR TITLE
Add retry mechanism on messaging.post_messaging_v2_multipart_message

### DIFF
--- a/src/inforion/messaging/messaging.py
+++ b/src/inforion/messaging/messaging.py
@@ -1,4 +1,6 @@
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from requests_toolbelt import MultipartEncoder
 
 import inforion.ionapi.model.inforlogin as inforlogin
@@ -7,6 +9,7 @@ import logging as log
 import json
 
 #logger = get_logger("my_module")
+
 
 def get_messaging_ping():
     try:
@@ -17,7 +20,6 @@ def get_messaging_ping():
         return res
     except Exception as e:
         log.error("Error ocurred " + str(e))
-
 
 
 def post_messaging_v2_multipart_message(parameter_request, message_payload):
@@ -31,9 +33,11 @@ def post_messaging_v2_multipart_message(parameter_request, message_payload):
         headers = inforlogin.header()
         headers.update({'Content-Type': data.content_type})
 
-        res = requests.post(url, headers=headers, data=data)
+        session = requests.Session()
+        retries = Retry(total=10, backoff_factor=1, status_forcelist=[502, 503, 504])
+        session.mount('https://', HTTPAdapter(max_retries=retries))
+        res = session.post(url, headers=headers, data=data)
         log.info('messaging v2 multipart message: {}'.format(res.content))
         return res
     except Exception as e:
         log.error("Error ocurred " + str(e))
-

--- a/src/inforion/messaging/messaging.py
+++ b/src/inforion/messaging/messaging.py
@@ -5,18 +5,19 @@ from requests_toolbelt import MultipartEncoder
 
 import inforion.ionapi.model.inforlogin as inforlogin
 import logging as log
-#from logger import get_logger
+
+# from logger import get_logger
 import json
 
-#logger = get_logger("my_module")
+# logger = get_logger("my_module")
 
 
 def get_messaging_ping():
     try:
-        url = inforlogin.base_url() + '/IONSERVICES/api/ion/messaging/service/ping'
+        url = inforlogin.base_url() + "/IONSERVICES/api/ion/messaging/service/ping"
         headers = inforlogin.header()
         res = requests.get(url, headers=headers)
-        log.info('messaging ping: {}'.format(res.content))
+        log.info("messaging ping: {}".format(res.content))
         return res
     except Exception as e:
         log.error("Error ocurred " + str(e))
@@ -24,20 +25,32 @@ def get_messaging_ping():
 
 def post_messaging_v2_multipart_message(parameter_request, message_payload):
     try:
-        url = inforlogin.base_url() + '/IONSERVICES/api/ion/messaging/service/v2/multipartMessage'
+        url = (
+            inforlogin.base_url()
+            + "/IONSERVICES/api/ion/messaging/service/v2/multipartMessage"
+        )
         data = MultipartEncoder(
-            fields={'ParameterRequest': ('filename', json.dumps(parameter_request), 'application/json'),
-                    'MessagePayload': ('filename', message_payload, 'application/octet-stream')
-                    }
+            fields={
+                "ParameterRequest": (
+                    "filename",
+                    json.dumps(parameter_request),
+                    "application/json",
+                ),
+                "MessagePayload": (
+                    "filename",
+                    message_payload,
+                    "application/octet-stream",
+                ),
+            }
         )
         headers = inforlogin.header()
-        headers.update({'Content-Type': data.content_type})
+        headers.update({"Content-Type": data.content_type})
 
         session = requests.Session()
         retries = Retry(total=10, backoff_factor=1, status_forcelist=[502, 503, 504])
-        session.mount('https://', HTTPAdapter(max_retries=retries))
+        session.mount("https://", HTTPAdapter(max_retries=retries))
         res = session.post(url, headers=headers, data=data)
-        log.info('messaging v2 multipart message: {}'.format(res.content))
+        log.info("messaging v2 multipart message: {}".format(res.content))
         return res
     except Exception as e:
         log.error("Error ocurred " + str(e))

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -7,7 +7,7 @@ from inforion.messaging.messaging import (
     post_messaging_v2_multipart_message,
 )
 
-''' Roberto fix it 
+
 def test_get_messaging_ping():
     inforlogin.load_config("credentials/credentials.ionapi")
     inforlogin.login()
@@ -61,6 +61,3 @@ def test_post_messaging_v2_multipart_message():
         ).status_code
         == 201
     )
-
-
-'''


### PR DESCRIPTION
Sometimes InforION send a 503 (Service Unavailable) error code. Documentation say to retry the http request.

_"Status codes 401, 500, 503, 504 are considered as a connection error. When such status code is received, the connection point retries sending the request again."_
https://docs.infor.com/ion/12.0.x/en-us/iontechconceag_cloud/default.html?helpcontent=fjx1567420498068.html
